### PR TITLE
Fixed incorrect variable line 22

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -17,9 +17,9 @@ namespace tehtävä1
             bool tulos;
             int iika;
             tulos = int.TryParse(ika, out iika);
-            if(tulos)
+            if (tulos)
             {
-                Console.WriteLine($"Ajattele {nimi.ToUpper()}, vuonna 2031 olet jo {ika + 10} vuotta vanha");
+                Console.WriteLine($"Ajattele {nimi.ToUpper()}, vuonna 2031 olet jo {iika + 10} vuotta vanha");
             }
             else
             {


### PR DESCRIPTION
Fixed variable on line 22 from ika to iika. Ika is string so it can't be counted. Variable iika is int so it can be counted. Also it seems that while saving Visual Studio Code wanted to format if(tulos) into if (tulos).